### PR TITLE
Search terms & embed support

### DIFF
--- a/MCatH/MCatH/1-13-1-16-panoramas.html
+++ b/MCatH/MCatH/1-13-1-16-panoramas.html
@@ -6,7 +6,41 @@
     <meta name="keywords" content="Contribute your computing power with BOINC!">
     <meta name="description" content="">
     <meta name="page_type" content="np-template-header-footer-from-plugin">
-    <title>1.13-1.16 Panoramas</title>
+
+	<!--Website information-->
+	<title>1.13-1.16 Panoramas - Minecraft@Home</title>
+	<meta name="description" content="The four Minecraft menu paronamas spanning 1.13 to 1.16.">
+	<meta name="keywords" content="MinecraftAtHome, Minecraft@Home, seed finding, minecraft, packpng">
+	<meta name="url" content="https://minecraftathome.com/">
+	<!--Open Graph meta tags-->
+	<meta property="og:site_name" content="Minecraft@Home"> <!--Website name-->
+	<meta property="og:title" content="1.13-1.16 Panoramas - Minecraft@Home"> <!--Page title-->
+	<meta property="og:description" content="The four Minecraft menu paronamas spanning 1.13 to 1.16.">
+	<meta property="og:image" content="https://github.com/minecrafthome/branding/blob/master/svg/mc%40h-icon-inverted.svg">
+
+	<!--fix this one when the pages are set up correctly
+	<meta property="og:url" content="https://minecraftathome.com/">-->
+
+	<meta property="og:type" content="website">
+	<meta property="og:locale" content="en_US">
+	<!--Twitter meta tags-->
+	<meta name="twitter:card" content="summary">
+	<meta name="twitter:title" content="1.13-1.16 Panoramas - Minecraft@Home">
+	<meta name="twitter:description" content="The four Minecraft menu paronamas spanning 1.13 to 1.16.">
+	<meta name="twitter:image" content="https://github.com/minecrafthome/branding/blob/master/svg/mc%40h-icon-inverted.svg">
+	<meta name="twitter:image:alt" content="Minecraft@Home white logo">
+	<meta name="site" content="@minecraftathome">
+	<!--Main link that search engines should use-->
+
+	<!--fix this one when the pages are set up correctly
+	<link rel="canonical" href="https://minecraftathome.com/">-->
+	
+	<!--Let search engines follow links and index the whole page-->
+	<meta name="robots" content="index, follow">
+	<!--Apple settings-->
+	<meta name="apple-mobile-web-app-capable" content="yes">
+	<meta name="apple-mobile-web-app-status-bar-style" content="black">
+	
     <link rel="stylesheet" href="nicepage.css" media="screen">
 <link rel="stylesheet" href="1-13-1-16-panoramas.css" media="screen">
     <script class="u-script" type="text/javascript" src="jquery.js" defer=""></script>

--- a/MCatH/MCatH/about.html
+++ b/MCatH/MCatH/about.html
@@ -6,7 +6,41 @@
     <meta name="keywords" content="">
     <meta name="description" content="">
     <meta name="page_type" content="np-template-header-footer-from-plugin">
-    <title>About</title>
+	
+	<!--Website information-->
+	<title>About - Minecraft@Home</title>
+	<meta name="description" content="We are an open community seeking to solve some of Minecraft's biggest mysteries.">
+	<meta name="keywords" content="MinecraftAtHome, Minecraft@Home, seed finding, minecraft, packpng">
+	<meta name="url" content="https://minecraftathome.com/">
+	<!--Open Graph meta tags-->
+	<meta property="og:site_name" content="Minecraft@Home"> <!--Website name-->
+	<meta property="og:title" content="About - Minecraft@Home"> <!--Page title-->
+	<meta property="og:description" content="We are an open community seeking to solve some of Minecraft's biggest mysteries.">
+	<meta property="og:image" content="https://github.com/minecrafthome/branding/blob/master/svg/mc%40h-icon-inverted.svg">
+
+	<!--fix this one when the pages are set up correctly
+	<meta property="og:url" content="https://minecraftathome.com/">-->
+
+	<meta property="og:type" content="website">
+	<meta property="og:locale" content="en_US">
+	<!--Twitter meta tags-->
+	<meta name="twitter:card" content="summary">
+	<meta name="twitter:title" content="About - Minecraft@Home">
+	<meta name="twitter:description" content="We are an open community seeking to solve some of Minecraft's biggest mysteries.">
+	<meta name="twitter:image" content="https://github.com/minecrafthome/branding/blob/master/svg/mc%40h-icon-inverted.svg">
+	<meta name="twitter:image:alt" content="Minecraft@Home white logo">
+	<meta name="site" content="@minecraftathome">
+	<!--Main link that search engines should use-->
+
+	<!--fix this one when the pages are set up correctly
+	<link rel="canonical" href="https://minecraftathome.com/">-->
+	
+	<!--Let search engines follow links and index the whole page-->
+	<meta name="robots" content="index, follow">
+	<!--Apple settings-->
+	<meta name="apple-mobile-web-app-capable" content="yes">
+	<meta name="apple-mobile-web-app-status-bar-style" content="black">
+
     <link rel="stylesheet" href="nicepage.css" media="screen">
 <link rel="stylesheet" href="about.css" media="screen">
     <script class="u-script" type="text/javascript" src="jquery.js" defer=""></script>

--- a/MCatH/MCatH/beta-panorama.html
+++ b/MCatH/MCatH/beta-panorama.html
@@ -6,7 +6,41 @@
     <meta name="keywords" content="Contribute your computing power with BOINC!">
     <meta name="description" content="">
     <meta name="page_type" content="np-template-header-footer-from-plugin">
-    <title>Beta Panorama</title>
+
+	<!--Website information-->
+	<title>Beta Panorama - Minecraft@Home</title>
+	<meta name="description" content="The menu background image from Beta 1.8 through Release 1.13">
+	<meta name="keywords" content="MinecraftAtHome, Minecraft@Home, seed finding, minecraft, packpng">
+	<meta name="url" content="https://minecraftathome.com/">
+	<!--Open Graph meta tags-->
+	<meta property="og:site_name" content="Minecraft@Home"> <!--Website name-->
+	<meta property="og:title" content="Beta Panorama - Minecraft@Home"> <!--Page title-->
+	<meta property="og:description" content="The menu background image from Beta 1.8 through Release 1.13">
+	<meta property="og:image" content="https://github.com/minecrafthome/branding/blob/master/svg/mc%40h-icon-inverted.svg">
+
+	<!--fix this one when the pages are set up correctly
+	<meta property="og:url" content="https://minecraftathome.com/">-->
+
+	<meta property="og:type" content="website">
+	<meta property="og:locale" content="en_US">
+	<!--Twitter meta tags-->
+	<meta name="twitter:card" content="summary">
+	<meta name="twitter:title" content="Beta Panorama - Minecraft@Home">
+	<meta name="twitter:description" content="The menu background image from Beta 1.8 through Release 1.13">
+	<meta name="twitter:image" content="https://github.com/minecrafthome/branding/blob/master/svg/mc%40h-icon-inverted.svg">
+	<meta name="twitter:image:alt" content="Minecraft@Home white logo">
+	<meta name="site" content="@minecraftathome">
+	<!--Main link that search engines should use-->
+
+	<!--fix this one when the pages are set up correctly
+	<link rel="canonical" href="https://minecraftathome.com/">-->
+	
+	<!--Let search engines follow links and index the whole page-->
+	<meta name="robots" content="index, follow">
+	<!--Apple settings-->
+	<meta name="apple-mobile-web-app-capable" content="yes">
+	<meta name="apple-mobile-web-app-status-bar-style" content="black">
+	
     <link rel="stylesheet" href="nicepage.css" media="screen">
 <link rel="stylesheet" href="beta-panorama.css" media="screen">
     <script class="u-script" type="text/javascript" src="jquery.js" defer=""></script>

--- a/MCatH/MCatH/herobrine.html
+++ b/MCatH/MCatH/herobrine.html
@@ -6,7 +6,41 @@
     <meta name="keywords" content="Contribute your computing power with BOINC!">
     <meta name="description" content="">
     <meta name="page_type" content="np-template-header-footer-from-plugin">
-    <title>Herobrine</title>
+
+	<!--Website information-->
+	<title>Herobrine - Minecraft@Home</title>
+	<meta name="description" content="Finding the seed behind the original Herobrine creepypasta image.">
+	<meta name="keywords" content="MinecraftAtHome, Minecraft@Home, seed finding, minecraft, packpng">
+	<meta name="url" content="https://minecraftathome.com/">
+	<!--Open Graph meta tags-->
+	<meta property="og:site_name" content="Minecraft@Home"> <!--Website name-->
+	<meta property="og:title" content="Herobrine - Minecraft@Home"> <!--Page title-->
+	<meta property="og:description" content="Finding the seed behind the original Herobrine creepypasta image.">
+	<meta property="og:image" content="https://github.com/minecrafthome/branding/blob/master/svg/mc%40h-icon-inverted.svg">
+
+	<!--fix this one when the pages are set up correctly
+	<meta property="og:url" content="https://minecraftathome.com/">-->
+
+	<meta property="og:type" content="website">
+	<meta property="og:locale" content="en_US">
+	<!--Twitter meta tags-->
+	<meta name="twitter:card" content="summary">
+	<meta name="twitter:title" content="Herobrine - Minecraft@Home">
+	<meta name="twitter:description" content="Finding the seed behind the original Herobrine creepypasta image.">
+	<meta name="twitter:image" content="https://github.com/minecrafthome/branding/blob/master/svg/mc%40h-icon-inverted.svg">
+	<meta name="twitter:image:alt" content="Minecraft@Home white logo">
+	<meta name="site" content="@minecraftathome">
+	<!--Main link that search engines should use-->
+
+	<!--fix this one when the pages are set up correctly
+	<link rel="canonical" href="https://minecraftathome.com/">-->
+	
+	<!--Let search engines follow links and index the whole page-->
+	<meta name="robots" content="index, follow">
+	<!--Apple settings-->
+	<meta name="apple-mobile-web-app-capable" content="yes">
+	<meta name="apple-mobile-web-app-status-bar-style" content="black">
+	
     <link rel="stylesheet" href="nicepage.css" media="screen">
 <link rel="stylesheet" href="herobrine.css" media="screen">
     <script class="u-script" type="text/javascript" src="jquery.js" defer=""></script>

--- a/MCatH/MCatH/list.html
+++ b/MCatH/MCatH/list.html
@@ -6,7 +6,41 @@
     <meta name="keywords" content="">
     <meta name="description" content="">
     <meta name="page_type" content="np-template-header-footer-from-plugin">
-    <title>List of Projects</title>
+	
+	<!--Website information-->
+	<title>Projects - Minecraft@Home</title>
+	<meta name="description" content="Within the past year, many of Minecraft's most famous seeds have been discovered by our community.">
+	<meta name="keywords" content="MinecraftAtHome, Minecraft@Home, seed finding, minecraft, packpng">
+	<meta name="url" content="https://minecraftathome.com/">
+	<!--Open Graph meta tags-->
+	<meta property="og:site_name" content="Minecraft@Home"> <!--Website name-->
+	<meta property="og:title" content="Projects - Minecraft@Home"> <!--Page title-->
+	<meta property="og:description" content="Within the past year, many of Minecraft's most famous seeds have been discovered by our community.">
+	<meta property="og:image" content="https://github.com/minecrafthome/branding/blob/master/svg/mc%40h-icon-inverted.svg">
+
+	<!--fix this one when the pages are set up correctly
+	<meta property="og:url" content="https://minecraftathome.com/">-->
+
+	<meta property="og:type" content="website">
+	<meta property="og:locale" content="en_US">
+	<!--Twitter meta tags-->
+	<meta name="twitter:card" content="summary">
+	<meta name="twitter:title" content="Projects - Minecraft@Home">
+	<meta name="twitter:description" content="Within the past year, many of Minecraft's most famous seeds have been discovered by our community.">
+	<meta name="twitter:image" content="https://github.com/minecrafthome/branding/blob/master/svg/mc%40h-icon-inverted.svg">
+	<meta name="twitter:image:alt" content="Minecraft@Home white logo">
+	<meta name="site" content="@minecraftathome">
+	<!--Main link that search engines should use-->
+
+	<!--fix this one when the pages are set up correctly
+	<link rel="canonical" href="https://minecraftathome.com/">-->
+	
+	<!--Let search engines follow links and index the whole page-->
+	<meta name="robots" content="index, follow">
+	<!--Apple settings-->
+	<meta name="apple-mobile-web-app-capable" content="yes">
+	<meta name="apple-mobile-web-app-status-bar-style" content="black">
+
     <link rel="stylesheet" href="nicepage.css" media="screen">
 <link rel="stylesheet" href="list.css" media="screen">
     <script class="u-script" type="text/javascript" src="jquery.js" defer=""></script>

--- a/MCatH/MCatH/official-trailer.html
+++ b/MCatH/MCatH/official-trailer.html
@@ -6,7 +6,41 @@
     <meta name="keywords" content="Contribute your computing power with BOINC!">
     <meta name="description" content="">
     <meta name="page_type" content="np-template-header-footer-from-plugin">
-    <title>Official Trailer</title>
+
+	<!--Website information-->
+	<title>Official Trailer - Minecraft@Home</title>
+	<meta name="description" content="Finding the worlds used to make the official Minecraft 1.0 release trailer.">
+	<meta name="keywords" content="MinecraftAtHome, Minecraft@Home, seed finding, minecraft, packpng">
+	<meta name="url" content="https://minecraftathome.com/">
+	<!--Open Graph meta tags-->
+	<meta property="og:site_name" content="Minecraft@Home"> <!--Website name-->
+	<meta property="og:title" content="Official Trailer - Minecraft@Home"> <!--Page title-->
+	<meta property="og:description" content="Finding the worlds used to make the official Minecraft 1.0 release trailer.">
+	<meta property="og:image" content="https://github.com/minecrafthome/branding/blob/master/svg/mc%40h-icon-inverted.svg">
+
+	<!--fix this one when the pages are set up correctly
+	<meta property="og:url" content="https://minecraftathome.com/">-->
+
+	<meta property="og:type" content="website">
+	<meta property="og:locale" content="en_US">
+	<!--Twitter meta tags-->
+	<meta name="twitter:card" content="summary">
+	<meta name="twitter:title" content="Official Trailer - Minecraft@Home">
+	<meta name="twitter:description" content="Finding the worlds used to make the official Minecraft 1.0 release trailer.">
+	<meta name="twitter:image" content="https://github.com/minecrafthome/branding/blob/master/svg/mc%40h-icon-inverted.svg">
+	<meta name="twitter:image:alt" content="Minecraft@Home white logo">
+	<meta name="site" content="@minecraftathome">
+	<!--Main link that search engines should use-->
+
+	<!--fix this one when the pages are set up correctly
+	<link rel="canonical" href="https://minecraftathome.com/">-->
+	
+	<!--Let search engines follow links and index the whole page-->
+	<meta name="robots" content="index, follow">
+	<!--Apple settings-->
+	<meta name="apple-mobile-web-app-capable" content="yes">
+	<meta name="apple-mobile-web-app-status-bar-style" content="black">
+	
     <link rel="stylesheet" href="nicepage.css" media="screen">
 <link rel="stylesheet" href="official-trailer.css" media="screen">
     <script class="u-script" type="text/javascript" src="jquery.js" defer=""></script>

--- a/MCatH/MCatH/packpng.html
+++ b/MCatH/MCatH/packpng.html
@@ -6,7 +6,41 @@
     <meta name="keywords" content="Contribute your computing power with BOINC!">
     <meta name="description" content="">
     <meta name="page_type" content="np-template-header-footer-from-plugin">
-    <title>Pack.PNG</title>
+
+	<!--Website information-->
+	<title>Pack.PNG - Minecraft@Home</title>
+	<meta name="description" content="The world of the famous Pack.PNG icon.">
+	<meta name="keywords" content="MinecraftAtHome, Minecraft@Home, seed finding, minecraft, packpng">
+	<meta name="url" content="https://minecraftathome.com/">
+	<!--Open Graph meta tags-->
+	<meta property="og:site_name" content="Minecraft@Home"> <!--Website name-->
+	<meta property="og:title" content="Pack.PNG - Minecraft@Home"> <!--Page title-->
+	<meta property="og:description" content="The world of the famous Pack.PNG icon.">
+	<meta property="og:image" content="https://github.com/minecrafthome/branding/blob/master/svg/mc%40h-icon-inverted.svg">
+
+	<!--fix this one when the pages are set up correctly
+	<meta property="og:url" content="https://minecraftathome.com/">-->
+
+	<meta property="og:type" content="website">
+	<meta property="og:locale" content="en_US">
+	<!--Twitter meta tags-->
+	<meta name="twitter:card" content="summary">
+	<meta name="twitter:title" content="Pack.PNG - Minecraft@Home">
+	<meta name="twitter:description" content="The world of the famous Pack.PNG icon.">
+	<meta name="twitter:image" content="https://github.com/minecrafthome/branding/blob/master/svg/mc%40h-icon-inverted.svg">
+	<meta name="twitter:image:alt" content="Minecraft@Home white logo">
+	<meta name="site" content="@minecraftathome">
+	<!--Main link that search engines should use-->
+
+	<!--fix this one when the pages are set up correctly
+	<link rel="canonical" href="https://minecraftathome.com/">-->
+	
+	<!--Let search engines follow links and index the whole page-->
+	<meta name="robots" content="index, follow">
+	<!--Apple settings-->
+	<meta name="apple-mobile-web-app-capable" content="yes">
+	<meta name="apple-mobile-web-app-status-bar-style" content="black">
+	
     <link rel="stylesheet" href="nicepage.css" media="screen">
 <link rel="stylesheet" href="packpng.css" media="screen">
     <script class="u-script" type="text/javascript" src="jquery.js" defer=""></script>

--- a/MCatH/MCatH/skull-painting.html
+++ b/MCatH/MCatH/skull-painting.html
@@ -6,7 +6,41 @@
     <meta name="keywords" content="Contribute your computing power with BOINC!">
     <meta name="description" content="">
     <meta name="page_type" content="np-template-header-footer-from-plugin">
-    <title>Skull Painting</title>
+
+	<!--Website information-->
+	<title>Skull on Fire Painting - Minecraft@Home</title>
+	<meta name="description" content="The world in the background of the Skull on Fire painting.">
+	<meta name="keywords" content="MinecraftAtHome, Minecraft@Home, seed finding, minecraft, packpng">
+	<meta name="url" content="https://minecraftathome.com/">
+	<!--Open Graph meta tags-->
+	<meta property="og:site_name" content="Minecraft@Home"> <!--Website name-->
+	<meta property="og:title" content="Skull on Fire Painting - Minecraft@Home"> <!--Page title-->
+	<meta property="og:description" content="The world in the background of the Skull on Fire painting.">
+	<meta property="og:image" content="https://github.com/minecrafthome/branding/blob/master/svg/mc%40h-icon-inverted.svg">
+
+	<!--fix this one when the pages are set up correctly
+	<meta property="og:url" content="https://minecraftathome.com/">-->
+
+	<meta property="og:type" content="website">
+	<meta property="og:locale" content="en_US">
+	<!--Twitter meta tags-->
+	<meta name="twitter:card" content="summary">
+	<meta name="twitter:title" content="Skull on Fire Painting - Minecraft@Home">
+	<meta name="twitter:description" content="The world in the background of the Skull on Fire painting.">
+	<meta name="twitter:image" content="https://github.com/minecrafthome/branding/blob/master/svg/mc%40h-icon-inverted.svg">
+	<meta name="twitter:image:alt" content="Minecraft@Home white logo">
+	<meta name="site" content="@minecraftathome">
+	<!--Main link that search engines should use-->
+
+	<!--fix this one when the pages are set up correctly
+	<link rel="canonical" href="https://minecraftathome.com/">-->
+	
+	<!--Let search engines follow links and index the whole page-->
+	<meta name="robots" content="index, follow">
+	<!--Apple settings-->
+	<meta name="apple-mobile-web-app-capable" content="yes">
+	<meta name="apple-mobile-web-app-status-bar-style" content="black">
+	
     <link rel="stylesheet" href="nicepage.css" media="screen">
 <link rel="stylesheet" href="skull-painting.css" media="screen">
     <script class="u-script" type="text/javascript" src="jquery.js" defer=""></script>

--- a/MCatH/MCatH/smash-backgrounds.html
+++ b/MCatH/MCatH/smash-backgrounds.html
@@ -6,7 +6,41 @@
     <meta name="keywords" content="Contribute your computing power with BOINC!">
     <meta name="description" content="">
     <meta name="page_type" content="np-template-header-footer-from-plugin">
-    <title>Smash Backgrounds</title>
+
+	<!--Website information-->
+	<title>Smash Backgrounds - Minecraft@Home</title>
+	<meta name="description" content="Finding the images used for Minecraft in Super Smash Bros.">
+	<meta name="keywords" content="MinecraftAtHome, Minecraft@Home, seed finding, minecraft, packpng">
+	<meta name="url" content="https://minecraftathome.com/">
+	<!--Open Graph meta tags-->
+	<meta property="og:site_name" content="Minecraft@Home"> <!--Website name-->
+	<meta property="og:title" content="Smash Backgrounds - Minecraft@Home"> <!--Page title-->
+	<meta property="og:description" content="Finding the images used for Minecraft in Super Smash Bros.">
+	<meta property="og:image" content="https://github.com/minecrafthome/branding/blob/master/svg/mc%40h-icon-inverted.svg">
+
+	<!--fix this one when the pages are set up correctly
+	<meta property="og:url" content="https://minecraftathome.com/">-->
+
+	<meta property="og:type" content="website">
+	<meta property="og:locale" content="en_US">
+	<!--Twitter meta tags-->
+	<meta name="twitter:card" content="summary">
+	<meta name="twitter:title" content="Smash Backgrounds - Minecraft@Home">
+	<meta name="twitter:description" content="Finding the images used for Minecraft in Super Smash Bros.">
+	<meta name="twitter:image" content="https://github.com/minecrafthome/branding/blob/master/svg/mc%40h-icon-inverted.svg">
+	<meta name="twitter:image:alt" content="Minecraft@Home white logo">
+	<meta name="site" content="@minecraftathome">
+	<!--Main link that search engines should use-->
+
+	<!--fix this one when the pages are set up correctly
+	<link rel="canonical" href="https://minecraftathome.com/">-->
+	
+	<!--Let search engines follow links and index the whole page-->
+	<meta name="robots" content="index, follow">
+	<!--Apple settings-->
+	<meta name="apple-mobile-web-app-capable" content="yes">
+	<meta name="apple-mobile-web-app-status-bar-style" content="black">
+	
     <link rel="stylesheet" href="nicepage.css" media="screen">
 <link rel="stylesheet" href="smash-backgrounds.css" media="screen">
     <script class="u-script" type="text/javascript" src="jquery.js" defer=""></script>

--- a/MCatH/MCatH/tallcactus.html
+++ b/MCatH/MCatH/tallcactus.html
@@ -6,7 +6,41 @@
     <meta name="keywords" content="Contribute your computing power with BOINC!">
     <meta name="description" content="">
     <meta name="page_type" content="np-template-header-footer-from-plugin">
-    <title>Tallest Cactus</title>
+
+	<!--Website information-->
+	<title>Tallest Cactus - Minecraft@Home</title>
+	<meta name="description" content="Using distributed computing to find super tall cactus.">
+	<meta name="keywords" content="MinecraftAtHome, Minecraft@Home, seed finding, minecraft, packpng">
+	<meta name="url" content="https://minecraftathome.com/">
+	<!--Open Graph meta tags-->
+	<meta property="og:site_name" content="Minecraft@Home"> <!--Website name-->
+	<meta property="og:title" content="Tallest Cactus - Minecraft@Home"> <!--Page title-->
+	<meta property="og:description" content="Using distributed computing to find super tall cactus.">
+	<meta property="og:image" content="https://github.com/minecrafthome/branding/blob/master/svg/mc%40h-icon-inverted.svg">
+
+	<!--fix this one when the pages are set up correctly
+	<meta property="og:url" content="https://minecraftathome.com/">-->
+
+	<meta property="og:type" content="website">
+	<meta property="og:locale" content="en_US">
+	<!--Twitter meta tags-->
+	<meta name="twitter:card" content="summary">
+	<meta name="twitter:title" content="Tallest Cactus - Minecraft@Home">
+	<meta name="twitter:description" content="Using distributed computing to find super tall cactus.">
+	<meta name="twitter:image" content="https://github.com/minecrafthome/branding/blob/master/svg/mc%40h-icon-inverted.svg">
+	<meta name="twitter:image:alt" content="Minecraft@Home white logo">
+	<meta name="site" content="@minecraftathome">
+	<!--Main link that search engines should use-->
+
+	<!--fix this one when the pages are set up correctly
+	<link rel="canonical" href="https://minecraftathome.com/">-->
+	
+	<!--Let search engines follow links and index the whole page-->
+	<meta name="robots" content="index, follow">
+	<!--Apple settings-->
+	<meta name="apple-mobile-web-app-capable" content="yes">
+	<meta name="apple-mobile-web-app-status-bar-style" content="black">
+	
     <link rel="stylesheet" href="nicepage.css" media="screen">
 <link rel="stylesheet" href="tallcactus.css" media="screen">
     <script class="u-script" type="text/javascript" src="jquery.js" defer=""></script>


### PR DESCRIPTION
Open Graph meta tags for general embed support and custom tags for Twitter exclusively.
Also added keywords and website descriptions for search engines.

The canonical links for all pages need to be fixed when the website is at the new/correct URLs
Fix `<link rel="canonical" href="https://minecraftathome.com/">` and `<meta property="og:url" content="https://minecraftathome.com/">` on each page.
They are currently as comments, so they don't mess anything up.